### PR TITLE
Use gnuconfig

### DIFF
--- a/posts/2020-10-29-macos-arm64.rst
+++ b/posts/2020-10-29-macos-arm64.rst
@@ -141,14 +141,14 @@ For autotools package, add the following to ``recipe/meta.yaml``,
 
    requirements:
      build:
-       - libtool   # [unix]
+       - gnuconfig   # [unix]
 
 and to ``recipe/build.sh``,
 
 .. code-block:: bash
 
    # Get an updated config.sub and config.guess
-   cp $BUILD_PREFIX/share/libtool/build-aux/config.* .
+   cp BUILD_PREFIX/share/gnuconfig/config.* .
 
 For cmake packages, add the following to ``recipe/build.sh``,
 


### PR DESCRIPTION
## how to add a blog post

1. Put your post in `.rst` format in the `posts` directory. Look at the other posts for the format. 
   Make sure you have a `.. post::` directive at the top and a section title at the top.
2. You can build your post via the commands `make clean`, `ablog build`, and `ablog serve`.
3. Checkout the results in your browser.
4. When you are ready, make a PR!
