### PR TITLE
add meson instructions to osx_arm64 migration instructions

### DIFF
--- a/posts/2020-10-29-macos-arm64.rst
+++ b/posts/2020-10-29-macos-arm64.rst
@@ -155,6 +155,19 @@ For cmake packages, add the following to ``recipe/build.sh``,
 .. code-block:: bash
 
    cmake ${CMAKE_ARGS} ..
+   
+For ``meson`` packages, add the following to ``recipe/build.sh``,
+
+.. code-block:: bash
+
+   meson ${MESON_ARGS} builddir/
+
+.. note::
+
+   Conda automatically creates a `cross build definition file <https://mesonbuild.com/Cross-compilation.html>`__ 
+   when cross-compiling, and adds
+   the necessary argument to ``${MESON_ARGS}`` to point ``meson`` to that file.
+   ``${MESON_ARGS}`` is only defined when cross-compiling, not for normal builds.
 
 For rust packages, add the following to ``recipe/meta.yaml``,
 


### PR DESCRIPTION
@isuruf 

## how to add a blog post

1. Put your post in `.rst` format in the `posts` directory. Look at the other posts for the format. 
   Make sure you have a `.. post::` directive at the top and a section title at the top.
2. You can build your post via the commands `make clean`, `ablog build`, and `ablog serve`.
3. Checkout the results in your browser.
4. When you are ready, make a PR!
