### PR TITLE
Remove deprecated test_on_native_only

### DIFF
--- a/posts/2020-10-29-macos-arm64.rst
+++ b/posts/2020-10-29-macos-arm64.rst
@@ -103,7 +103,7 @@ will send PRs to is determined by the list of packages at
 `conda-forge-pinning <https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/master/recipe/migrations/osx_arm64.txt>`_
 and their dependences. If you would like to add support, please send a PR
 adding the feedstock name to the above list. After that PR is merged,
-you can monitor the status at `conda-forge status-page <https://conda-forge.org/status/#armosxaddition>`
+you can monitor the status at `conda-forge status-page <https://conda-forge.org/status/#armosxaddition>`_
 and if a particular PR is stalled you can send a PR to the feedstock
 to fix it.
 
@@ -115,7 +115,7 @@ Add the following to ``conda-forge.yml`` (on Linux or OSX),
 
    build_platform:
      osx_arm64: osx_64
-   test_on_native_only: true
+   test: native_and_emulated
 
 You can rerender using,
 


### PR DESCRIPTION
Since `test_on_native_only` is [deprecated](https://conda-forge.org/docs/maintainer/conda_forge_yml.html#test-on-native-only), we should switch it to `test: native_and_emulated`.
This behavior is already updated in the rego-cf-autotick-bot, see [here](https://github.com/conda-forge/scalene-feedstock/pull/1).

Also, this PR fixes a url typo.